### PR TITLE
Update README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Pull requests are welcome :) Please get in touch with one us beforehand: `rionbr
 Tests
 -----
 
-Run nosetests -v to perform tests and diagnoses on functions.
+Before running the test suite, install the project dependencies with `pip install -r requirements.txt` (ideally inside a virtual environment).
+
+Run `pytest -q` to execute the automated tests and verify functionality.
 
 
 Changelog


### PR DESCRIPTION
## Summary
- update the README tests section to reference the pytest command actually used by the project
- add guidance for installing dependencies before running the tests

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d8d386d6f8832da593ce93e4e370ea

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update README tests section to add dependency install step and switch to `pytest` command.
> 
> - **Documentation**:
>   - **README `Tests` section**:
>     - Add dependency installation step: `pip install -r requirements.txt`.
>     - Update test execution command to `pytest -q` (replacing prior `nosetests -v` guidance).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60caec63095ac001cfd47b47431198048abd691c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->