### PR TITLE
Add drawing reference documentation and Graphviz guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Docs:
 -------
 
 The full documentation can be found at: [casci-lab.github.io/CANA/](https://casci-lab.github.io/CANA/)
+Plotting helpers are described in the [drawing reference](https://casci-lab.github.io/CANA/reference/drawing.html);
+install the Graphviz system package alongside the Python ``graphviz`` module
+before using these functions.
 
 
 Papers:

--- a/docs/source/reference/drawing.rst
+++ b/docs/source/reference/drawing.rst
@@ -1,0 +1,33 @@
+Drawing
+=======
+
+The :mod:`cana.drawing` module gathers utilities for visualising canalization
+structures and Boolean node behaviour. These helpers rely on external
+visualisation backends, so make sure the required dependencies are available
+before calling them.
+
+.. note::
+
+   The canalizing map renderer depends on both the Graphviz **system
+   package** (providing the ``dot`` command line tools) and the
+   :mod:`graphviz` **Python package** that ships the bindings used by
+   ``cana``. Install the operating system package through your package
+   manager (for example ``apt install graphviz`` or ``brew install
+   graphviz``) and then install the Python bindings with ``pip install
+   graphviz``.
+
+Canalizing maps
+---------------
+
+.. currentmodule:: cana.drawing.canalizing_map
+
+.. autofunction:: draw_canalizing_map_graphviz
+
+Look-up tables
+--------------
+
+.. currentmodule:: cana.drawing.plot_look_up_table
+
+.. autofunction:: plot_look_up_table
+
+.. autofunction:: plot_annigen_look_up_table

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -12,9 +12,10 @@ API Reference
 	:maxdepth: 2
 	
 	node
-	network
-	canalization/index
-	control/index
-	datasets/index
-	ensemble
-	utils
+        network
+        canalization/index
+        control/index
+        datasets/index
+        ensemble
+        drawing
+        utils


### PR DESCRIPTION
## Summary
- add a drawing reference page documenting the plotting utilities in `cana.drawing`
- include the new drawing page in the API reference table of contents for discoverability
- mention the drawing docs and Graphviz prerequisites in the README

## Testing
- make -C docs html *(fails: `sphinx-build` command missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d38d869c832db9cb956c40c746eb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a drawing reference page for `cana.drawing`, links it in the API reference, and documents Graphviz requirements in the README.
> 
> - **Docs**:
>   - **New Reference Page**: Adds `docs/source/reference/drawing.rst` documenting `cana.drawing` helpers:
>     - `cana.drawing.canalizing_map.draw_canalizing_map_graphviz`
>     - `cana.drawing.plot_look_up_table.plot_look_up_table`, `plot_annigen_look_up_table`
>   - **Dependencies Note**: Explains need for Graphviz system package and Python `graphviz` module for canalizing map rendering.
>   - **README**: Mentions drawing reference and Graphviz prerequisites.
>   - **API TOC**: Includes `drawing` in `docs/source/reference/index.rst` toctree.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49450d732dbfbf1ee43c740e32a91704a6d0ef24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->