### PR TITLE
docs: expand canalization reference overview

### DIFF
--- a/docs/source/reference/canalization/index.rst
+++ b/docs/source/reference/canalization/index.rst
@@ -3,5 +3,30 @@
 Canalization
 ==============
 
+Canalization tools in CANA reveal how Boolean network logic can be simplified by
+identifying redundant or dispensable inputs. Use this module when you want to
+quantify how stable a node's behavior is under perturbations, compare the
+controllability of different subnetworks, or derive reduced representations that
+highlight decisive control structures before running large-scale simulations.
+
+The tutorials in the project repository walk through full analysis workflows—see
+`Canalization - BioModels.ipynb <https://github.com/rionbr/CANA/blob/master/tutorials/Canalization%20-%20BioModels.ipynb>`_.
+For a catalogue of functions and parameters refer to the
+:mod:`cana.canalization.boolean_canalization` API reference.
+
+.. rubric:: Quick start
+
+.. code-block:: python
+
+    from cana.datasets import bio
+
+    # Load a bundled biological network and inspect the first node
+    network = bio.MARQUESPITA()
+    node = network.nodes[0]
+
+    # Calculate a canalization measure (input redundancy) and print it
+    redundancy = node.input_redundancy()
+    print(f"{node.name} input redundancy: {redundancy:.3f}")
+
 .. automodule:: cana.canalization.boolean_canalization
-	:members:
+        :members:


### PR DESCRIPTION
## Summary
- add an overview paragraph and resource links to the canalization reference page
- include a quick-start example that loads a bundled network and reports input redundancy

## Testing
- PYTHONPATH=/workspace/CANA make html

------
https://chatgpt.com/codex/tasks/task_e_68d8d3b8a1fc832d87c07ad73612c94e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the canalization reference page with an overview, tutorial/API links, and a quick-start code example.
> 
> - **Docs – `docs/source/reference/canalization/index.rst`**:
>   - **Overview**: Adds concise description of canalization tools and common use cases.
>   - **Resources**: Links to tutorial notebook and `cana.canalization.boolean_canalization` API reference.
>   - **Quick start**: Adds Python snippet loading a bundled network and computing `node.input_redundancy()`.
>   - Keeps `.. automodule:: cana.canalization.boolean_canalization` with `:members:` (formatting adjusted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a93f5210d7bedeca499daaeae4551f9aa83b9871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->