### PR TITLE
Add control workflow overview to control reference docs

### DIFF
--- a/docs/source/reference/control/index.rst
+++ b/docs/source/reference/control/index.rst
@@ -6,6 +6,23 @@ Control
 These are methods and modules used to calculate control in Boolean Networks. They are divided in dynamics- and structure-based methods.
 
 Note that these methods do not need to be called directly, as :class:`cana.boolean_network.BooleanNetwork` provides the appropriate methods.
+A typical control workflow starts by instantiating a :class:`.BooleanNetwork`, computing its attractors, and then evaluating which driver nodes are necessary to steer the system between those attractors. The reference below documents the individual helpers that make up that workflow.
+
+.. code-block:: python
+
+    from cana.boolean_network import BooleanNetwork
+
+    # Define a two-node toggle switch where each gene inhibits the other.
+    logic = {
+        0: {"name": "A", "in": [1], "out": ["1", "0"]},
+        1: {"name": "B", "in": [0], "out": ["1", "0"]},
+    }
+
+    bn = BooleanNetwork.from_dict(logic, name="Toggle switch")
+    driver_sets = bn.attractor_driver_nodes()
+    print(driver_sets)
+
+The resulting ``driver_sets`` list contains the minimal node index combinations capable of reaching every attractor—each entry represents one feasible set of driver variables. See also the :doc:`../datasets/networks` catalogue for curated biological networks that you can explore with the same approach.
 
 .. contents:: Contents
 	:depth: 3


### PR DESCRIPTION
## Summary
- describe the typical Boolean network control workflow in the reference guide
- add a runnable-style example that demonstrates computing attractor driver nodes
- link to the datasets reference so readers can explore additional networks

## Testing
- make html

------
https://chatgpt.com/codex/tasks/task_e_68d8d3c2550c832db6d2a8790014cd02

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a concise control workflow overview with a runnable-style example for computing attractor driver nodes and links to the datasets reference.
> 
> - **Docs (control reference)**:
>   - Add brief workflow overview explaining how to instantiate a `BooleanNetwork`, compute attractors, and evaluate driver nodes.
>   - Include a code example demonstrating `BooleanNetwork.from_dict` and `attractor_driver_nodes()`.
>   - Link readers to `../datasets/networks` for curated networks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae7b5ef910352d2cf0ce30c63fcbfd1cde930214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->